### PR TITLE
Unmount react component when WpBlock is disconnected

### DIFF
--- a/assets/js/base/utils/bhe-frontend.tsx
+++ b/assets/js/base/utils/bhe-frontend.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { ReactElement } from 'react';
+import { unmountComponentAtNode } from 'react-dom';
 
 /**
  * Internal dependencies
@@ -149,6 +150,11 @@ class WpBlock extends HTMLElement {
 				hydrationOptions
 			);
 		} );
+	}
+
+	disconnectedCallback() {
+		// Unmount the React component, running callbacks and cleaning up its state.
+		unmountComponentAtNode( this );
 	}
 }
 


### PR DESCRIPTION
Simply carries over @DAreRodz' https://github.com/WordPress/block-hydration-experiments/pull/47 from the BHE repo. See that PR for more information 🙂 