### PR TITLE
Add `blocks-hydration-experiments` blocks

### DIFF
--- a/assets/js/blocks/bhe/.eslintrc
+++ b/assets/js/blocks/bhe/.eslintrc
@@ -1,0 +1,7 @@
+{
+	"rules": {
+		"@woocommerce/dependency-group": "off",
+		"react/no-unescaped-entities": "off",
+		"no-duplicate-imports": "off"
+	}
+}

--- a/assets/js/blocks/bhe/bhe.d.ts
+++ b/assets/js/blocks/bhe/bhe.d.ts
@@ -1,0 +1,6 @@
+declare module 'bhe/src/gutenberg-packages/frontend';
+declare module 'bhe/src/gutenberg-packages/react-context';
+declare module 'bhe/src/gutenberg-packages/utils';
+declare module 'bhe/src/gutenberg-packages/wordpress-blockeditor';
+declare module 'bhe/src/gutenberg-packages/wordpress-blocks';
+declare module 'bhe/src/gutenberg-packages/wordpress-element';

--- a/assets/js/blocks/bhe/blocks/interactive-child/block.json
+++ b/assets/js/blocks/bhe/blocks/interactive-child/block.json
@@ -15,7 +15,8 @@
 		"typography": {
 			"fontSize": true
 		},
-		"html": true
+		"html": true,
+		"view": true
 	},
 	"textdomain": "block-hydration-experiments",
 	"editorScript": "file:./index.js",

--- a/assets/js/blocks/bhe/blocks/interactive-child/block.json
+++ b/assets/js/blocks/bhe/blocks/interactive-child/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "bhe/interactive-child",
+	"version": "0.1.0",
+	"title": "BHE - Interactive Child",
+	"category": "text",
+	"icon": "flag",
+	"description": "",
+	"usesContext": ["bhe/interactive-title", "bhe/non-interactive-title"],
+	"supports": {
+		"color": {
+			"text": true
+		},
+		"typography": {
+			"fontSize": true
+		},
+		"html": true
+	},
+	"textdomain": "block-hydration-experiments",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./frontend.js"
+}

--- a/assets/js/blocks/bhe/blocks/interactive-child/block.json
+++ b/assets/js/blocks/bhe/blocks/interactive-child/block.json
@@ -19,7 +19,5 @@
 		"view": true
 	},
 	"textdomain": "block-hydration-experiments",
-	"editorScript": "file:./index.js",
-	"style": "file:./style-index.css",
-	"viewScript": "file:./frontend.js"
+	"style": "file:./style-index.css"
 }

--- a/assets/js/blocks/bhe/blocks/interactive-child/edit.js
+++ b/assets/js/blocks/bhe/blocks/interactive-child/edit.js
@@ -1,0 +1,22 @@
+// This import is needed to ensure that the `wp.blockEditor` global is available
+// by the time this component gets loaded. The `Title` component consumes the
+// global but cannot import it because it shouldn't be loaded on the frontend of
+// the site.
+import '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
+
+const Edit = ( { context } ) => (
+	<div { ...useBlockProps() }>
+		<p>
+			Block Context from interactive parent - "bhe/interactive-title":{ ' ' }
+			{ context[ 'bhe/interactive-title' ] }
+		</p>
+		<p>
+			Block Context from non-interactive parent -
+			"bhe/non-interactive-title":{ ' ' }
+			{ context[ 'bhe/non-interactive-title' ] }
+		</p>
+	</div>
+);
+
+export default Edit;

--- a/assets/js/blocks/bhe/blocks/interactive-child/frontend.js
+++ b/assets/js/blocks/bhe/blocks/interactive-child/frontend.js
@@ -1,0 +1,8 @@
+import CounterContext from '../../context/counter';
+import ThemeContext from '../../context/theme';
+import { registerBlockType } from 'bhe/src/gutenberg-packages/frontend';
+import View from './view';
+
+registerBlockType( 'bhe/interactive-child', View, {
+	usesContext: [ ThemeContext, CounterContext ],
+} );

--- a/assets/js/blocks/bhe/blocks/interactive-child/index.js
+++ b/assets/js/blocks/bhe/blocks/interactive-child/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from 'bhe/src/gutenberg-packages/wordpress-blocks';
+import Edit from './edit';
+import View from './view';
+import './style.scss';
+
+registerBlockType( 'bhe/interactive-child', {
+	edit: Edit,
+	view: View, // The Save component is derived from the View component.
+} );

--- a/assets/js/blocks/bhe/blocks/interactive-child/style.scss
+++ b/assets/js/blocks/bhe/blocks/interactive-child/style.scss
@@ -1,0 +1,23 @@
+.wp-block-bhe-interactive-child {
+	padding: 15px 10px 15px 50px;
+	border: 1px solid rgb(255, 162, 0);
+	position: relative;
+}
+
+.wp-block-bhe-interactive-child::before {
+	position: absolute;
+	top: 0;
+	right: 0;
+	border: 1px solid rgb(255, 162, 0);
+	background-color: rgb(255, 162, 0);
+	color: white;
+	margin: -1px;
+	padding: 0px 5px;
+	font-size: 9px;
+	content: 'BHE - Interactive Child';
+}
+
+wp-block,
+wp-inner-blocks {
+	display: contents;
+}

--- a/assets/js/blocks/bhe/blocks/interactive-child/view.js
+++ b/assets/js/blocks/bhe/blocks/interactive-child/view.js
@@ -1,0 +1,26 @@
+import CounterContext from '../../context/counter';
+import ThemeContext from '../../context/theme';
+import { useContext } from 'bhe/src/gutenberg-packages/wordpress-element';
+
+const View = ( { blockProps, context } ) => {
+	const theme = useContext( ThemeContext );
+	const counter = useContext( CounterContext );
+
+	return (
+		<div { ...blockProps }>
+			<p>
+				Block Context from interactive parent - "bhe/interactive-title":{ ' ' }
+				{ context[ 'bhe/interactive-title' ] }
+			</p>
+			<p>
+				Block Context from non-interactive parent -
+				"bhe/non-interactive-title":{ ' ' }
+				{ context[ 'bhe/non-interactive-title' ] }
+			</p>
+			<p>React Context - "counter": { counter }</p>
+			<p>React Context - "theme": { theme }</p>
+		</div>
+	);
+};
+
+export default View;

--- a/assets/js/blocks/bhe/blocks/interactive-parent/block.json
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/block.json
@@ -33,7 +33,8 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true
 		},
-		"html": true
+		"html": true,
+		"view": true
 	},
 	"providesContext": {
 		"bhe/interactive-title": "title"

--- a/assets/js/blocks/bhe/blocks/interactive-parent/block.json
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/block.json
@@ -1,0 +1,46 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "bhe/interactive-parent",
+	"version": "0.1.0",
+	"title": "BHE - Interactive Parent",
+	"category": "text",
+	"icon": "flag",
+	"description": "",
+	"attributes": {
+		"counter": {
+			"type": "number",
+			"default": 0,
+			"public": true
+		},
+		"title": {
+			"type": "string",
+			"source": "text",
+			"selector": ".title",
+			"public": true
+		},
+		"secret": {
+			"type": "string",
+			"default": "fa4e3d47e4e0a38c5c57533391855013"
+		}
+	},
+	"supports": {
+		"color": {
+			"text": true
+		},
+		"typography": {
+			"fontSize": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true
+		},
+		"html": true
+	},
+	"providesContext": {
+		"bhe/interactive-title": "title"
+	},
+	"usesContext": ["bhe/non-interactive-title"],
+	"textdomain": "block-hydration-experiments",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./frontend.js"
+}

--- a/assets/js/blocks/bhe/blocks/interactive-parent/block.json
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/block.json
@@ -41,7 +41,5 @@
 	},
 	"usesContext": ["bhe/non-interactive-title"],
 	"textdomain": "block-hydration-experiments",
-	"editorScript": "file:./index.js",
-	"style": "file:./style-index.css",
-	"viewScript": "file:./frontend.js"
+	"style": "file:./style-index.css"
 }

--- a/assets/js/blocks/bhe/blocks/interactive-parent/edit.js
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/edit.js
@@ -1,0 +1,33 @@
+// This import is needed to ensure that the `wp.blockEditor` global is available
+// by the time this component gets loaded. The `Title` component consumes the
+// global but cannot import it because it shouldn't be loaded on the frontend of
+// the site.
+import '@wordpress/block-editor';
+
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import Button from './shared/button';
+import Title from './shared/title';
+
+const Edit = ( { attributes: { counter, title, secret }, setAttributes } ) => (
+	<>
+		<div { ...useBlockProps() }>
+			<Title
+				onChange={ ( val ) => setAttributes( { title: val } ) }
+				placeholder="This will be passed through context to child blocks"
+			>
+				{ title }
+			</Title>
+			<Button>Show</Button>
+			<button onClick={ () => setAttributes( { counter: counter + 1 } ) }>
+				{ counter }
+			</button>
+			<blockquote style={ { fontSize: '10px' } }>
+				This is a secret attribute that should not be serialized:{ ' ' }
+				{ secret }
+			</blockquote>
+			<InnerBlocks />
+		</div>
+	</>
+);
+
+export default Edit;

--- a/assets/js/blocks/bhe/blocks/interactive-parent/frontend.js
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/frontend.js
@@ -1,0 +1,8 @@
+import CounterContext from '../../context/counter';
+import ThemeContext from '../../context/theme';
+import { registerBlockType } from 'bhe/src/gutenberg-packages/frontend';
+import View from './view';
+
+registerBlockType( 'bhe/interactive-parent', View, {
+	providesContext: [ ThemeContext, CounterContext ],
+} );

--- a/assets/js/blocks/bhe/blocks/interactive-parent/index.js
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from 'bhe/src/gutenberg-packages/wordpress-blocks';
+import Edit from './edit';
+import View from './view';
+import './style.scss';
+
+registerBlockType( 'bhe/interactive-parent', {
+	edit: Edit,
+	view: View, // The Save component is derived from the View component.
+} );

--- a/assets/js/blocks/bhe/blocks/interactive-parent/shared/button.js
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/shared/button.js
@@ -1,0 +1,5 @@
+const Button = ( { handler, children } ) => {
+	return <button onClick={ handler }>{ children }</button>;
+};
+
+export default Button;

--- a/assets/js/blocks/bhe/blocks/interactive-parent/shared/title.js
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/shared/title.js
@@ -1,0 +1,9 @@
+import { RichText } from 'bhe/src/gutenberg-packages/wordpress-blockeditor';
+
+const Title = ( { children, ...props } ) => (
+	<RichText tagName="h2" className="title" { ...props }>
+		{ children }
+	</RichText>
+);
+
+export default Title;

--- a/assets/js/blocks/bhe/blocks/interactive-parent/style.scss
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/style.scss
@@ -1,0 +1,23 @@
+.wp-block-bhe-interactive-parent {
+	padding: 15px 10px 15px 50px;
+	border: 1px solid rgb(31, 185, 64);
+	position: relative;
+}
+
+.wp-block-bhe-interactive-parent::before {
+	position: absolute;
+	top: 0;
+	right: 0;
+	background-color: rgb(31, 185, 64);
+	border: 1px solid rgb(31, 185, 64);
+	color: white;
+	margin: -1px;
+	padding: 0px 5px;
+	font-size: 10px;
+	content: 'BHE - Interactive Parent';
+}
+
+wp-block,
+wp-inner-blocks {
+	display: contents;
+}

--- a/assets/js/blocks/bhe/blocks/interactive-parent/view.js
+++ b/assets/js/blocks/bhe/blocks/interactive-parent/view.js
@@ -1,0 +1,42 @@
+import Counter from '../../context/counter';
+import Theme from '../../context/theme';
+import { useState } from 'bhe/src/gutenberg-packages/wordpress-element';
+import Button from './shared/button';
+import Title from './shared/title';
+
+const View = ( {
+	blockProps: {
+		className,
+		style: { fontWeight, ...style },
+	},
+	attributes: { counter: initialCounter, title },
+	children,
+} ) => {
+	const [ show, setShow ] = useState( true );
+	const [ bold, setBold ] = useState( true );
+	const [ counter, setCounter ] = useState( initialCounter );
+
+	return (
+		<Counter.Provider value={ counter }>
+			<Theme.Provider value="cool theme">
+				<div
+					className={ `${ className } ${ show ? 'show' : 'hide' }` }
+					style={ {
+						...style,
+						fontWeight: bold ? 900 : fontWeight,
+					} }
+				>
+					<Title>{ title }</Title>
+					<Button handler={ () => setShow( ! show ) }>Show</Button>
+					<Button handler={ () => setBold( ! bold ) }>Bold</Button>
+					<button onClick={ () => setCounter( counter + 1 ) }>
+						{ counter }
+					</button>
+					{ show && children }
+				</div>
+			</Theme.Provider>
+		</Counter.Provider>
+	);
+};
+
+export default View;

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/block.json
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/block.json
@@ -22,7 +22,10 @@
 		"color": {
 			"text": true
 		},
-		"html": true
+		"html": true,
+		"view": {
+			"hydration": false
+		}
 	},
 	"textdomain": "block-hydration-experiments",
 	"editorScript": "file:./index.js",

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/block.json
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/block.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "bhe/non-interactive-parent",
+	"version": "0.1.0",
+	"title": "BHE - Non Interactive Parent",
+	"category": "text",
+	"icon": "flag",
+	"description": "",
+	"attributes": {
+		"title": {
+			"type": "string",
+			"source": "text",
+			"selector": ".title",
+			"public": true
+		}
+	},
+	"providesContext": {
+		"bhe/non-interactive-title": "title"
+	},
+	"supports": {
+		"color": {
+			"text": true
+		},
+		"html": true
+	},
+	"textdomain": "block-hydration-experiments",
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/block.json
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/block.json
@@ -28,6 +28,5 @@
 		}
 	},
 	"textdomain": "block-hydration-experiments",
-	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"
 }

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/edit.js
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/edit.js
@@ -1,0 +1,18 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { RichText } from 'bhe/src/gutenberg-packages/wordpress-blockeditor';
+
+const Edit = ( { attributes, setAttributes } ) => (
+	<div { ...useBlockProps() }>
+		<RichText
+			tagName="h4"
+			className="title"
+			onChange={ ( val ) => setAttributes( { title: val } ) }
+			placeholder="This will be passed through context to child blocks"
+			value={ attributes.title }
+		>
+			{ attributes.title }
+		</RichText>
+		<InnerBlocks />
+	</div>
+);
+export default Edit;

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/index.js
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/index.js
@@ -1,0 +1,12 @@
+import { registerBlockType } from 'bhe/src/gutenberg-packages/wordpress-blocks';
+import metadata from './block.json';
+import Edit from './edit';
+import View from './view';
+import './style.scss';
+
+const { name } = metadata;
+
+registerBlockType( name, {
+	edit: Edit,
+	view: View, // The Save component is derived from the View component.
+} );

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/style.scss
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/style.scss
@@ -1,0 +1,23 @@
+.wp-block-bhe-non-interactive-parent {
+	border: 1px solid rgb(34, 168, 235);
+	position: relative;
+	padding: 25px 10px;
+}
+
+.wp-block-bhe-non-interactive-parent::before {
+	content: 'BHE - Non Interactive Parent';
+	position: absolute;
+	top: 0;
+	right: 0;
+	border: 1px solid rgb(34, 168, 235);
+	background-color: rgb(34, 168, 235);
+	color: white;
+	margin: -1px;
+	padding: 0px 5px;
+	font-size: 10px;
+}
+
+wp-block,
+wp-inner-blocks {
+	display: contents;
+}

--- a/assets/js/blocks/bhe/blocks/non-interactive-parent/view.js
+++ b/assets/js/blocks/bhe/blocks/non-interactive-parent/view.js
@@ -1,0 +1,8 @@
+const View = ({ attributes, blockProps, children }) => (
+	<div {...blockProps}>
+		<p className="title">{attributes.title}</p>
+		{children}
+	</div>
+);
+
+export default View;

--- a/assets/js/blocks/bhe/context/counter.js
+++ b/assets/js/blocks/bhe/context/counter.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+if ( typeof window.reactContext === 'undefined' ) {
+	window.reactContext = createContext( null );
+}
+window.reactContext.displayName = 'CounterContext';
+export default window.reactContext;

--- a/assets/js/blocks/bhe/context/theme.js
+++ b/assets/js/blocks/bhe/context/theme.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+if ( typeof window.themeReactContext === 'undefined' ) {
+	window.themeReactContext = createContext( null );
+}
+window.themeReactContext.displayName = 'ThemeContext';
+export default window.themeReactContext;

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -87,7 +87,7 @@ const getCoreConfig = ( options = {} ) => {
 			rules: [
 				{
 					test: /\.(t|j)sx?$/,
-					exclude: /node_modules/,
+					exclude: /node_modules\/(?!(bhe)\/).*/,
 					use: {
 						loader: 'babel-loader?cacheDirectory',
 						options: {
@@ -196,7 +196,7 @@ const getMainConfig = ( options = {} ) => {
 			rules: [
 				{
 					test: /\.(j|t)sx?$/,
-					exclude: /node_modules/,
+					exclude: /node_modules\/(?!(bhe)\/).*/,
 					use: {
 						loader: 'babel-loader?cacheDirectory',
 						options: {
@@ -329,7 +329,7 @@ const getFrontConfig = ( options = {} ) => {
 			rules: [
 				{
 					test: /\.(j|t)sx?$/,
-					exclude: /node_modules/,
+					exclude: /node_modules\/(?!(bhe)\/).*/,
 					use: {
 						loader: 'babel-loader?cacheDirectory',
 						options: {

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -57,6 +57,18 @@ const blocks = {
 	'legacy-template': {
 		customDir: 'classic-template',
 	},
+	'interactive-child': {
+		customDir: 'bhe/blocks/interactive-child',
+		isExperimental: true,
+	},
+	'interactive-parent': {
+		customDir: 'bhe/blocks/interactive-parent',
+		isExperimental: true,
+	},
+	'non-interactive-parent': {
+		customDir: 'bhe/blocks/non-interactive-parent',
+		isExperimental: true,
+	},
 };
 
 // Returns the entries for each block given a relative path (ie: `index.js`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@wordpress/server-side-render": "3.10.0",
 				"@wordpress/url": "3.13.0",
 				"@wordpress/wordcount": "3.13.0",
+				"bhe": "WordPress/block-hydration-experiments",
 				"classnames": "2.3.1",
 				"compare-versions": "4.1.3",
 				"config": "3.3.7",
@@ -18568,6 +18569,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/bhe": {
+			"name": "block-hydration-experiments",
+			"version": "0.1.0",
+			"resolved": "git+ssh://git@github.com/WordPress/block-hydration-experiments.git#2a15bce031cc502cd4a5cb9d7f09548cd3c12fd0",
+			"license": "GPL-2.0-or-later"
 		},
 		"node_modules/big-integer": {
 			"version": "1.6.51",
@@ -65790,6 +65797,10 @@
 					}
 				}
 			}
+		},
+		"bhe": {
+			"version": "git+ssh://git@github.com/WordPress/block-hydration-experiments.git#2a15bce031cc502cd4a5cb9d7f09548cd3c12fd0",
+			"from": "bhe@WordPress/block-hydration-experiments"
 		},
 		"big-integer": {
 			"version": "1.6.51",

--- a/package.json
+++ b/package.json
@@ -234,7 +234,8 @@
 		"snakecase-keys": "5.4.2",
 		"trim-html": "0.1.9",
 		"use-debounce": "7.0.1",
-		"wordpress-components": "npm:@wordpress/components@14.2.0"
+		"wordpress-components": "npm:@wordpress/components@14.2.0",
+		"bhe": "WordPress/block-hydration-experiments"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/src/BlockTypes/InteractiveChild.php
+++ b/src/BlockTypes/InteractiveChild.php
@@ -1,0 +1,21 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * InteractiveChild class.
+ */
+class InteractiveChild extends AbstractBlock {
+	/**
+	 * Block namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'bhe';
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'interactive-child';
+}

--- a/src/BlockTypes/InteractiveParent.php
+++ b/src/BlockTypes/InteractiveParent.php
@@ -1,0 +1,21 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * InteractiveParent class.
+ */
+class InteractiveParent extends AbstractBlock {
+	/**
+	 * Block namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'bhe';
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'interactive-parent';
+}

--- a/src/BlockTypes/NonInteractiveParent.php
+++ b/src/BlockTypes/NonInteractiveParent.php
@@ -18,4 +18,14 @@ class NonInteractiveParent extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'non-interactive-parent';
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }

--- a/src/BlockTypes/NonInteractiveParent.php
+++ b/src/BlockTypes/NonInteractiveParent.php
@@ -1,0 +1,21 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * NonInteractiveParent class.
+ */
+class NonInteractiveParent extends AbstractBlock {
+	/**
+	 * Block namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'bhe';
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'non-interactive-parent';
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -138,21 +138,12 @@ final class BlockTypesController {
 	 * @return string
 	 */
 	public function block_hydration_wrapper( $block_content, $block, $instance ) {
-		// We might want to use a flag from block.json as the criterion here.
-		if ( ! in_array(
-			$block['blockName'],
-			array(
-				'woocommerce/all-products',
-				'bhe/non-interactive-parent',
-				'bhe/interactive-parent',
-				'bhe/interactive-child',
-			),
-			true
-		) ) {
+		$block_type = $instance->block_type;
+
+		if ( ! block_has_support( $block_type, [ 'view' ] ) ) {
 			return $block_content;
 		}
 
-		$block_type       = $instance->block_type;
 		$attr_definitions = $block_type->attributes;
 
 		$attributes         = array();
@@ -174,6 +165,8 @@ final class BlockTypesController {
 			}
 		}
 
+		$hydration_technique = $block_type->supports['view']['hydration'] ?? 'idle';
+
 		$previous_block_to_render = \WP_Block_Supports::$block_to_render;
 		// TODO: The following is a bit hacky. If we stick with this technique, we might
 		// want to change apply_block_supports() to accepts a block as its argument.
@@ -189,13 +182,14 @@ final class BlockTypesController {
 			'data-wp-block-attributes="%4$s" ' .
 			'data-wp-block-sourced-attributes="%5$s" ' .
 			'data-wp-block-props="%6$s" ' .
-			'data-wp-block-hydration="idle">',
+			'data-wp-block-hydration="%7$s">',
 			esc_attr( $block['blockName'] ),
 			esc_attr( wp_json_encode( $block_type->uses_context ) ),
 			esc_attr( wp_json_encode( $block_type->provides_context ) ),
 			esc_attr( wp_json_encode( $attributes ) ),
 			esc_attr( wp_json_encode( $sourced_attributes ) ),
-			esc_attr( wp_json_encode( $block_supports_attributes ) )
+			esc_attr( wp_json_encode( $block_supports_attributes ) ),
+			esc_attr( $hydration_technique )
 		) . '%1$s</wp-block>';
 
 		$template_wrapper = '<template class="wp-inner-blocks">%1$s</template>';

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -143,6 +143,9 @@ final class BlockTypesController {
 			$block['blockName'],
 			array(
 				'woocommerce/all-products',
+				'bhe/non-interactive-parent',
+				'bhe/interactive-parent',
+				'bhe/interactive-child',
 			),
 			true
 		) ) {
@@ -279,6 +282,9 @@ final class BlockTypesController {
 			'ProductTitle',
 			'MiniCart',
 			'MiniCartContents',
+			'InteractiveChild',
+			'InteractiveParent',
+			'NonInteractiveParent',
 		];
 
 		$block_types = array_merge( $block_types, Cart::get_cart_block_types(), Checkout::get_checkout_block_types() );


### PR DESCRIPTION
As I posted in the [tracking issue](https://github.com/woocommerce/woocommerce-blocks-hydration-experiments/issues/20#issuecomment-1210938588), I plan to write some blocks from scratch ― specifically the Checkout and inner blocks. That means creating new blocks.

This PR adds the blocks we already implemented in [WordPress/block-hydration-experiments](https://github.com/WordPress/block-hydration-experiments/) to understand better what is needed to include more blocks in the repo. This also includes the files needed to share context between blocks. 