### PR TITLE
Remove BHE exports from utils

### DIFF
--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -8,5 +8,3 @@ export * from './product-data';
 export * from './derive-selected-shipping-rates';
 export * from './get-icons-from-payment-methods';
 export * from './parse-style';
-export * from './bhe-frontend';
-export * from './bhe-element';


### PR DESCRIPTION
Looks like we accidentally introduced these [here](https://github.com/woocommerce/woocommerce-blocks-hydration-experiments/pull/39/files#diff-b1f2eacd00a094cfdf9ca09fbfb8ea734306805ada4af1ef6042bec87c617405R10). Unfortunately, they can cause a race condition, as discussed [here](https://github.com/woocommerce/woocommerce-blocks-hydration-experiments/pull/21#issuecomment-1205248320).